### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ npm install reasondb
 
 ### Loading
 
-Users of Chrome 54.0 and greater can use the file at src/index.js so long as node-uuid is loaded first (67K): 
+Users of Chrome 54.0 and greater can use the file at src/index.js so long as uuid is loaded first (67K): 
 
 ```
-<script src="../node_modules/node-uuid/uuid.js"></script>
+<script src="../node_modules/uuid/uuid.js"></script>
 <script src="../src/index.js"></script>
 ```
 

--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<script src="../../node_modules/node-uuid/uuid.js"></script>
+<script src="../../node_modules/uuid/uuid.js"></script>
 <!-- script src="../../node_modules/bluebird/js/browser/bluebird.js"></script -->
 <script src="../../node_modules/localforage/dist/localforage.js"></script>
 <!-- script src="../../src/index.js"></script -->

--- a/examples/load/insert.html
+++ b/examples/load/insert.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<script src="../../node_modules/node-uuid/uuid.js"></script>
+<script src="../../node_modules/uuid/uuid.js"></script>
 <!-- script src="../../node_modules/bluebird/js/browser/bluebird.js"></script -->
 <script src="../../node_modules/localforage/dist/localforage.js"></script>
 <script src="../../src/index.js"></script>

--- a/examples/load/read.html
+++ b/examples/load/read.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<script src="../../node_modules/node-uuid/uuid.js"></script>
+<script src="../../node_modules/uuid/uuid.js"></script>
 <!-- script src="../../node_modules/bluebird/js/browser/bluebird.js"></script -->
 <script src="../../node_modules/localforage/dist/localforage.js"></script>
 <script src="../../src/index.js"></script>

--- a/examples/load/select.html
+++ b/examples/load/select.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<script src="../../node_modules/node-uuid/uuid.js"></script>
+<script src="../../node_modules/uuid/uuid.js"></script>
 <!-- script src="../../node_modules/bluebird/js/browser/bluebird.js"></script -->
 <script src="../../node_modules/localforage/dist/localforage.js"></script>
 <script src="../../src/index.js"></script>

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,7 +102,7 @@ SOFTWARE.
 	    fs = void 0;
 	if (typeof window === "undefined") {
 		var r = require;
-		_uuid = r("node-uuid");
+		_uuid = r("uuid");
 		fs = r("fs");
 	}
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "babel-runtime": "^6.11.6",
     "graceful-fs": "^4.1.9",
     "localforage": "^1.4.3",
-    "node-uuid": "^1.4.7",
+    "uuid": "^3.0.0",
     "write-file-atomic": "^1.2.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ SOFTWARE.
 	let _uuid, fs;
 	if(typeof(window)==="undefined") {
 		let r = require;
-		_uuid = r("node-uuid");
+		_uuid = r("uuid");
 		fs = r("fs");
 	}
 	

--- a/test/index.html
+++ b/test/index.html
@@ -5,7 +5,7 @@
 <script src="../node_modules/mocha/mocha.js" type="text/javascript"></script>
 <script src="../node_modules/chai/chai.js" type="text/javascript"></script>
 <script src="../node_modules/localforage/dist/localforage.js"></script>
-<script src="../node_modules/node-uuid/uuid.js"></script>
+<script src="../node_modules/uuid/uuid.js"></script>
 <!-- script src="../node_modules/bluebird/js/browser/bluebird.js"></script -->
 <!-- script src="../node_modules/blanket/dist/qunit/blanket.min.js" data-cover-adapter="mocha-blanket.js"></script -->
 <script src="../browser/reasondb.js" data-cover></script>


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.